### PR TITLE
fix: Make memory_manager optional in MemorySearchTool and MemoryGetTool

### DIFF
--- a/agentmesh/memory/tools/memory_get.py
+++ b/agentmesh/memory/tools/memory_get.py
@@ -13,50 +13,41 @@ from agentmesh.memory.manager import MemoryManager
 class MemoryGetTool(BaseTool):
     """Tool for reading memory file contents"""
     
-    def __init__(self, memory_manager: MemoryManager):
+    # Use class attributes instead of instance attributes
+    name: str = "memory_get"
+    description: str = (
+        "Read specific memory file content by path and line range. "
+        "Use after memory_search to get full context from historical memory files."
+    )
+    params: dict = {
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": "Relative path to the memory file (e.g., 'MEMORY.md', 'memory/2024-01-29.md')"
+            },
+            "start_line": {
+                "type": "integer",
+                "description": "Starting line number (optional, default: 1)",
+                "default": 1
+            },
+            "num_lines": {
+                "type": "integer",
+                "description": "Number of lines to read (optional, reads all if not specified)"
+            }
+        },
+        "required": ["path"]
+    }
+    
+    def __init__(self, memory_manager: Optional[MemoryManager] = None):
         """
         Initialize memory get tool
         
         Args:
-            memory_manager: MemoryManager instance
+            memory_manager: MemoryManager instance (optional, required for actual execution)
         """
         super().__init__()
         self.memory_manager = memory_manager
-        self._name = "memory_get"
-        self._description = (
-            "Read specific memory file content by path and line range. "
-            "Use after memory_search to get full context from historical memory files."
-        )
-    
-    @property
-    def name(self) -> str:
-        return self._name
-    
-    @property
-    def description(self) -> str:
-        return self._description
-    
-    @property
-    def parameters(self) -> Dict[str, Any]:
-        return {
-            "type": "object",
-            "properties": {
-                "path": {
-                    "type": "string",
-                    "description": "Relative path to the memory file (e.g., 'MEMORY.md', 'memory/2024-01-29.md')"
-                },
-                "start_line": {
-                    "type": "integer",
-                    "description": "Starting line number (optional, default: 1)",
-                    "default": 1
-                },
-                "num_lines": {
-                    "type": "integer",
-                    "description": "Number of lines to read (optional, reads all if not specified)"
-                }
-            },
-            "required": ["path"]
-        }
     
     async def execute(self, **kwargs) -> str:
         """
@@ -70,6 +61,9 @@ class MemoryGetTool(BaseTool):
         Returns:
             File content
         """
+        if self.memory_manager is None:
+            return "Error: Memory manager not configured. This tool requires a MemoryManager instance."
+        
         path = kwargs.get("path")
         start_line = kwargs.get("start_line", 1)
         num_lines = kwargs.get("num_lines")

--- a/agentmesh/memory/tools/memory_search.py
+++ b/agentmesh/memory/tools/memory_search.py
@@ -12,54 +12,45 @@ from agentmesh.memory.manager import MemoryManager
 class MemorySearchTool(BaseTool):
     """Tool for searching agent memory"""
     
-    def __init__(self, memory_manager: MemoryManager, user_id: Optional[str] = None):
+    # Use class attributes instead of instance attributes
+    name: str = "memory_search"
+    description: str = (
+        "Search historical memory files (beyond today/yesterday) using semantic and keyword search. "
+        "Recent context (MEMORY.md + today + yesterday) is already loaded. "
+        "Use this ONLY for older dates, specific past events, or when current context lacks needed info."
+    )
+    params: dict = {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Search query (can be natural language question or keywords)"
+            },
+            "max_results": {
+                "type": "integer",
+                "description": "Maximum number of results to return (default: 10)",
+                "default": 10
+            },
+            "min_score": {
+                "type": "number",
+                "description": "Minimum relevance score (0-1, default: 0.3)",
+                "default": 0.3
+            }
+        },
+        "required": ["query"]
+    }
+    
+    def __init__(self, memory_manager: Optional[MemoryManager] = None, user_id: Optional[str] = None):
         """
         Initialize memory search tool
         
         Args:
-            memory_manager: MemoryManager instance
+            memory_manager: MemoryManager instance (optional, required for actual execution)
             user_id: Optional user ID for scoped search
         """
         super().__init__()
         self.memory_manager = memory_manager
         self.user_id = user_id
-        self._name = "memory_search"
-        self._description = (
-            "Search historical memory files (beyond today/yesterday) using semantic and keyword search. "
-            "Recent context (MEMORY.md + today + yesterday) is already loaded. "
-            "Use this ONLY for older dates, specific past events, or when current context lacks needed info."
-        )
-    
-    @property
-    def name(self) -> str:
-        return self._name
-    
-    @property
-    def description(self) -> str:
-        return self._description
-    
-    @property
-    def parameters(self) -> Dict[str, Any]:
-        return {
-            "type": "object",
-            "properties": {
-                "query": {
-                    "type": "string",
-                    "description": "Search query (can be natural language question or keywords)"
-                },
-                "max_results": {
-                    "type": "integer",
-                    "description": "Maximum number of results to return (default: 10)",
-                    "default": 10
-                },
-                "min_score": {
-                    "type": "number",
-                    "description": "Minimum relevance score (0-1, default: 0.3)",
-                    "default": 0.3
-                }
-            },
-            "required": ["query"]
-        }
     
     async def execute(self, **kwargs) -> str:
         """
@@ -73,6 +64,9 @@ class MemorySearchTool(BaseTool):
         Returns:
             Formatted search results
         """
+        if self.memory_manager is None:
+            return "Error: Memory manager not configured. This tool requires a MemoryManager instance."
+        
         query = kwargs.get("query")
         max_results = kwargs.get("max_results", 10)
         min_score = kwargs.get("min_score", 0.3)


### PR DESCRIPTION
Fixes #8

## Problem

When running `python main.py -l`, the tool loader attempts to instantiate all tool classes without arguments to get their names:

```python
temp_instance = cls()
```

However, `MemorySearchTool` and `MemoryGetTool` require `memory_manager` as a mandatory parameter, causing initialization errors:

```
Error initializing tool class MemorySearchTool: __init__() missing 1 required positional argument: 'memory_manager'
Error initializing tool class MemoryGetTool: __init__() missing 1 required positional argument: 'memory_manager'
```

## Solution

This PR aligns the memory tools with the implementation pattern used by other tools (e.g., `Read`, `Write`):

1. **Use class attributes** instead of instance attributes:
   - `name: str` instead of `self._name` with `@property`
   - `description: str` instead of `self._description` with `@property`
   - `params: dict` for JSON schema

2. **Make `memory_manager` optional**:
   - Changed from `memory_manager: MemoryManager` to `memory_manager: Optional[MemoryManager] = None`
   - Added runtime check when `execute()` is called
   - Returns clear error message if memory_manager is not configured

## Changes

- Modified `agentmesh/memory/tools/memory_search.py`
- Modified `agentmesh/memory/tools/memory_get.py`
- Modified `agentmesh/tools/memory/memory_search.py`
- Modified `agentmesh/tools/memory/memory_get.py`

## Testing

Before fix:
```bash
$ python main.py -l
Error initializing tool class MemorySearchTool: ...
Error initializing tool class MemoryGetTool: ...
Available teams:
  - general_team: ...
```

After fix:
```bash
$ python main.py -l
Available teams:
  - general_team: A versatile research and information agent team
  - software_team: A software development team with product manager, developer and tester.
```

No more initialization errors! ✅