### PR TITLE
fix: Add max_turns None check and enhanced error logging

### DIFF
--- a/agentmesh/protocol/agent_stream.py
+++ b/agentmesh/protocol/agent_stream.py
@@ -88,6 +88,11 @@ class AgentStreamExecutor:
 
         final_response = ""
         turn = 0
+        
+        # Safety check: ensure max_turns is valid
+        if self.max_turns is None:
+            logger.warning("max_turns is None, using default value 10")
+            self.max_turns = 10
 
         try:
             while turn < self.max_turns:
@@ -159,7 +164,9 @@ class AgentStreamExecutor:
                 logger.warning(f"Reached max turns: {self.max_turns}")
 
         except Exception as e:
+            import traceback
             logger.error(f"Agent execution error: {e}")
+            logger.error(f"Full traceback:\n{traceback.format_exc()}")
             self._emit_event("error", {"error": str(e)})
             raise
 


### PR DESCRIPTION
## Problem

After PR #10 fixed the `_trim_messages` None comparison issue, users still encounter the same error:

```
[ERROR][2026-02-03 21:34:48][agent_stream.py:162] - Agent execution error: '<' not supported between instances of 'int' and 'NoneType'
```

**Root cause**: The error occurs at **line 93** in the main execution loop:

```python
while turn < self.max_turns:  # TypeError if max_turns is None
```

If `max_turns` is `None` (can happen when `Agent.__init__` receives `max_steps=None`), the comparison `turn < self.max_turns` fails with `TypeError`.

## Solution

### 1. Add max_turns validation before loop

```python
# Safety check: ensure max_turns is valid
if self.max_turns is None:
    logger.warning("max_turns is None, using default value 10")
    self.max_turns = 10
```

**Location**: Lines 91-96 in `agentmesh/protocol/agent_stream.py`

**Benefits**:
- Prevents TypeError in main execution loop
- Uses safe default value (10 turns)
- Warning log helps identify configuration issues
- Agent continues execution instead of crashing

### 2. Enhanced error logging

```python
except Exception as e:
    import traceback
    logger.error(f"Agent execution error: {e}")
    logger.error(f"Full traceback:\n{traceback.format_exc()}")  # Added
    self._emit_event("error", {"error": str(e)})
    raise
```

**Location**: Lines 166-169

**Benefits**:
- Full stack trace for easier debugging
- Helps identify exact error location
- Useful for future error diagnosis

## Testing

**Before fix**:
```bash
$ python3.9 main.py -t general_team -q "hi"
[ERROR] Agent execution error: '<' not supported between instances of 'int' and 'NoneType'
```

**After fix**:
```bash
$ python3.9 main.py -t general_team -q "hi"
[WARNING] max_turns is None, using default value 10
# Agent executes normally
```

## Why max_turns can be None

1. `Agent.__init__` has parameter `max_steps=100` (default)
2. But if caller passes `max_steps=None` explicitly
3. This gets passed to `AgentStreamExecutor` as `max_turns=None`
4. Line 93 comparison fails

This fix adds defensive programming to handle this edge case.

## Impact

- ✅ Fixes user-reported production error
- ✅ Maintains backward compatibility
- ✅ Provides clear diagnostics via warnings
- ✅ Safe fallback behavior (10 turns default)
- ✅ Better debugging with full tracebacks

## Related PRs

- PR #9: Fixed memory tools initialization ✅ Merged
- PR #10: Fixed `_trim_messages` None check ✅ Merged
- This PR: Fixes main loop None check (completes the fix series)